### PR TITLE
Remove qurl from Tupfile

### DIFF
--- a/src/Tupfile
+++ b/src/Tupfile
@@ -1,7 +1,7 @@
 CC = clang
 CFLAGS += -g -Weverything -Wno-disabled-macro-expansion -Wno-unused-parameter -fstack-protector-all -fpie -pie -Wl,-z,relro,-z,now -std=c11
 LIBS += `pkg-config --libs-only-l libcurl`
-SRC = hr.c isitup.c lsip.c qurl.c sicolor.c steamlib.c
+SRC = hr.c isitup.c lsip.c sicolor.c steamlib.c
 #SRC = hr.c isitup.c lsip.c qurl.c sicolor.c pipes.c
 
 : foreach $(SRC) | ansicolor.h |> $(CC) $(CFLAGS) $(LIBS) %f -o %o |> %B.out


### PR DESCRIPTION
Since qurl.c was removed, the tup build has been broken because the reference wasn't removed here :-)
