### PR TITLE
tzathura: bug fixes

### DIFF
--- a/tzathura
+++ b/tzathura
@@ -1,4 +1,7 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
+[[ ! -f "$1" ]] && echo "No such file" && exit 1
+
+IFS="" # treat argument with spaces as a single argument
 [[ -z $((xprop -id $(</tmp/zathura.xid)) 2>/dev/null) ]] && tabbed -f -p s+1 -n "docs" -d > /tmp/zathura.xid
 exec zathura -e $(</tmp/zathura.xid) $( [[  "$1"  ]] && echo "$1") &


### PR DESCRIPTION
- Giving the script a file that doesn't exist would open an empty `tabbed` tab.
- Files with spaces in the path were treated like multiple files.
